### PR TITLE
CREATE a PaCkAGE BUilD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Arch makepkg
+/pkg
+/*.zst

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,14 @@
+# Maintainer: Dave Lucia <davelucianyc@gmail.com>
+pkgname=spongebob
+pkgver=0.1.0
+pkgrel=1
+makedepends=('rust' 'cargo')
+arch=('i686' 'x86_64' 'armv6h' 'armv7h')
+
+build() {
+  cargo build --release --locked --all-features
+}
+
+package() {
+  install -Dm 755 ${startdir}/target/release/${pkgname} -t "${pkgdir}/usr/bin"
+}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ FLAGS:
 OPTIONS:
     -s, --style <style>    quiet, loud or normal
 ```
+
+## Install on Arch
+
+If you're running on Arch Linux you can install the package by building with the included `PKGBUILD`.
+
+```bash
+# Build the package
+makepkg
+
+# Install the resulting package file
+sudo pacman -U spongebob-0.1.0-1-x86_64.pkg.tar.zst
+```


### PR DESCRIPTION
Adds a simple PKGBUILD and ignores the folders/files that `makepkg`
generates.